### PR TITLE
Allow building through cmake fetch content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,4 @@ project(dds_image LANGUAGES CXX)
 add_library(dds_image INTERFACE)
 target_include_directories(dds_image INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 
-add_subdirectory("${CMAKE_SOURCE_DIR}/tests")
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,11 @@ cmake_minimum_required(VERSION 3.0)
 
 project(dds_image LANGUAGES CXX)
 
+option(DDS_BUILD_TESTS "Builds DDS related tests for the library" OFF)
+
 add_library(dds_image INTERFACE)
 target_include_directories(dds_image INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 
-add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")
+if (DDS_BUILD_TESTS)
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")
+endif()


### PR DESCRIPTION
Uses CMAKE_CURRENT_SOURCE_DIR instead of global CMAKE_SOURCE_DIR. Without this change the path to tests would be incorrect when embedded through cmake fetch content.