### PR TITLE
Fix missing <memory> include

### DIFF
--- a/include/dds_formats.hpp
+++ b/include/dds_formats.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #if defined(_MSVC_LANG)


### PR DESCRIPTION
Fix missing include in header required for `std::unique_ptr`.

Introduced in 6af872605e727bd6651a27bc4d91894613a07f08 after switching from `std::vector`