### PR TITLE
Fix DXGI_FORMAT_R8G8_UINT map to VK_FORMAT_R8G8_SINT

### DIFF
--- a/include/dds.hpp
+++ b/include/dds.hpp
@@ -254,7 +254,7 @@ namespace dds {
             case DXGI_FORMAT_R8G8_UNORM:
                 return VK_FORMAT_R8G8_UNORM;
             case DXGI_FORMAT_R8G8_UINT:
-                return VK_FORMAT_R8G8_SINT;
+                return VK_FORMAT_R8G8_UINT;
             case DXGI_FORMAT_R8G8_SNORM:
                 return VK_FORMAT_R8G8_SNORM;
             case DXGI_FORMAT_R8G8_SINT:


### PR DESCRIPTION
Fix incorrect mapping from `DXGI_FORMAT_R8G8_UINT` library type to `VK_FORMAT_R8G8_SINT` vulkan type. Now it maps to `VK_FORMAT_R8G8_UINT` as expected.

Probably a typo.