### PR TITLE
Change `readImage` function so input data comes as const pointer

### DIFF
--- a/include/dds.hpp
+++ b/include/dds.hpp
@@ -415,9 +415,9 @@ namespace dds {
 	 * When using this function, image->data will always be empty and the mipmap span's will reference
 	 * the passed pointer.
 	 */
-	DDS_NO_DISCARD inline ReadResult readImage(std::uint8_t* ptr, std::size_t fileSize, dds::Image* image) {
+	DDS_NO_DISCARD inline ReadResult readImage(const std::uint8_t* ptr, std::size_t fileSize, dds::Image* image) {
         // Read the magic number
-        auto* ddsMagic = reinterpret_cast<uint32_t*>(ptr);
+        const auto* ddsMagic = reinterpret_cast<const uint32_t*>(ptr);
         ptr += sizeof(uint32_t);
 
         // Read the header


### PR DESCRIPTION
Input `std::uint8_t` pointer is currently expected as non const pointer, however `readImage` does not edit the actual memory since it's only meant to read data.

While this isn't an issue for readFile, it becomes problematic when calling readImage to load a DDS from raw memory