### PR TITLE
Fix span to reference memory as non-mutable

### DIFF
--- a/include/dds_formats.hpp
+++ b/include/dds_formats.hpp
@@ -321,6 +321,6 @@ namespace dds {
         bool supportsAlpha = false;
         DXGI_FORMAT format;
         std::unique_ptr<uint8_t[]> data = nullptr;
-        std::vector<dds::span<uint8_t>> mipmaps;
+        std::vector<dds::span<const uint8_t>> mipmaps;
     };
 } // namespace dds


### PR DESCRIPTION
Fix for missing commit in my previous PR (#13)

Since now the pointer sent to `readImage` is const, the span can't modify it.

Hope this won't break anything @spnda 